### PR TITLE
Refactor: Move to a more manageable state

### DIFF
--- a/core/dist/server.js
+++ b/core/dist/server.js
@@ -1,0 +1,98 @@
+import underPressure from "@fastify/under-pressure";
+import Fastify from "fastify";
+import noIcon from "fastify-no-icon";
+import fp from "fastify-plugin";
+import fknex from "fastify-knexjs";
+const knexConfig = {
+  development: {
+    client: "postgresql",
+    connection: {
+      database: "tillwhen",
+      user: "postgres",
+      password: "postgres"
+    },
+    pool: {
+      min: 2,
+      max: 2
+    },
+    migrations: {
+      tableName: "migrations"
+    }
+  },
+  staging: {
+    client: "postgresql",
+    connection: process.env.DATABASE_URL,
+    pool: {
+      min: 2,
+      max: 2
+    },
+    migrations: {
+      tableName: "migrations"
+    }
+  },
+  production: {
+    client: "postgresql",
+    connection: process.env.DATABASE_URL,
+    pool: {
+      min: 2,
+      max: 2
+    },
+    migrations: {
+      tableName: "migrations"
+    }
+  }
+};
+const config = {
+  port: 3e3,
+  databaseConfig: knexConfig[process.env.NODE_ENV || "development"]
+};
+const routerPlugin = fp(
+  function(fastify, options, done) {
+    fastify.after(() => {
+      fastify.get("/ping", async (req, res) => {
+        await res.send({ pong: true });
+      });
+    });
+    done();
+  },
+  {
+    name: "routes"
+  }
+);
+const db = fp(
+  function(fastify, options, done) {
+    const connectionConfig = knexConfig[process.env.NODE_ENV || "development"];
+    fastify.register(fknex, connectionConfig);
+    done();
+  },
+  {
+    name: "database"
+  }
+);
+function createServer() {
+  const server = Fastify({
+    logger: true
+  });
+  server.decorate("config", config);
+  server.register(routerPlugin);
+  server.register(db);
+  server.register(underPressure, {
+    maxEventLoopDelay: 1e3,
+    maxHeapUsedBytes: 1e8,
+    maxRssBytes: 1e8,
+    maxEventLoopUtilization: 0.98
+  });
+  server.register(noIcon);
+  return server;
+}
+function main() {
+  const app = createServer();
+  app.listen({ port: app.config.port }, (err) => {
+    if (err) {
+      app.log.error(err.message);
+      process.exit(1);
+    }
+    app.log.info("http://127.0.0.1:8000/foo");
+  });
+}
+main();

--- a/core/knexfile.js
+++ b/core/knexfile.js
@@ -1,0 +1,43 @@
+// Update with your config settings.
+
+export default {
+  development: {
+    client: 'postgresql',
+    connection: {
+      database: 'tillwhen',
+      user: 'postgres',
+      password: 'postgres',
+    },
+    pool: {
+      min: 2,
+      max: 2,
+    },
+    migrations: {
+      tableName: 'migrations',
+    },
+  },
+
+  staging: {
+    client: 'postgresql',
+    connection: process.env.DATABASE_URL,
+    pool: {
+      min: 2,
+      max: 2,
+    },
+    migrations: {
+      tableName: 'migrations',
+    },
+  },
+
+  production: {
+    client: 'postgresql',
+    connection: process.env.DATABASE_URL,
+    pool: {
+      min: 2,
+      max: 2,
+    },
+    migrations: {
+      tableName: 'migrations',
+    },
+  },
+}

--- a/core/package.json
+++ b/core/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "core",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "prettier": "@barelyhuman/prettier-config",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@fastify/autoload": "^5.10.0",
+    "@fastify/under-pressure": "^8.5.1",
+    "fastify": "^4.28.1",
+    "fastify-knexjs": "^1.4.0",
+    "fastify-lcache": "^2.1.1",
+    "fastify-no-icon": "^6.0.0",
+    "fastify-plugin": "^4.5.1"
+  },
+  "devDependencies": {
+    "@barelyhuman/prettier-config": "^1.1.0",
+    "prettier": "^2.8.8",
+    "tsm": "^2.3.0",
+    "vite": "^5.3.3",
+    "vite-plugin-fastify": "^1.2.5"
+  }
+}

--- a/core/src/app.ts
+++ b/core/src/app.ts
@@ -1,0 +1,32 @@
+import underPressure from '@fastify/under-pressure'
+import Fastify from 'fastify'
+import noIcon from 'fastify-no-icon'
+import { config } from './config'
+import routerPlugin from './plugins/routes'
+import db from './plugins/db'
+import domain from './plugins/domain/domain'
+
+export function createServer() {
+  const server = Fastify({
+    logger: true,
+  })
+
+  server.decorate('config', config)
+
+  server.register(routerPlugin)
+  server.register(db)
+  server.register(domain)
+
+  server.register(underPressure, {
+    maxEventLoopDelay: 1000,
+    maxHeapUsedBytes: 100000000,
+    maxRssBytes: 100000000,
+    maxEventLoopUtilization: 0.98,
+  })
+
+  server.register(noIcon)
+
+  return server
+}
+
+export default createServer

--- a/core/src/config.ts
+++ b/core/src/config.ts
@@ -1,0 +1,11 @@
+import knexConfig from '../knexfile'
+import type { Knex } from 'knex'
+
+export const config = {
+  port: 3000,
+  databaseConfig: knexConfig[
+    process.env.NODE_ENV || 'development'
+  ] as Knex.Config,
+}
+
+export type Config = typeof config

--- a/core/src/plugins/db.ts
+++ b/core/src/plugins/db.ts
@@ -1,0 +1,14 @@
+import fb from 'fastify-plugin'
+import fknex from 'fastify-knexjs'
+import knexConfig from '../../knexfile.js'
+
+export default fb(
+  function (fastify, options, done) {
+    const connectionConfig = knexConfig[process.env.NODE_ENV || 'development']
+    fastify.register(fknex, connectionConfig)
+    done()
+  },
+  {
+    name: 'database',
+  }
+)

--- a/core/src/plugins/domain/domain.ts
+++ b/core/src/plugins/domain/domain.ts
@@ -1,0 +1,23 @@
+import fp from 'fastify-plugin'
+import { fetchUserById } from './knex/user'
+
+export type Domain = ReturnType<typeof getDomain>
+
+function getDomain(fastify) {
+  return {
+    user: {
+      fetchUserById: (id: number) => fetchUserById(fastify.knex, id),
+    },
+  }
+}
+
+export default fp(
+  function (fastify, _, done) {
+    fastify.decorate('domain', getDomain(fastify))
+    done()
+  },
+  {
+    name: 'domain',
+    dependencies: ['database'],
+  }
+)

--- a/core/src/plugins/domain/knex/user.ts
+++ b/core/src/plugins/domain/knex/user.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex'
+
+export const fetchUserById = (db: Knex, id: number) => {
+  return db('users')
+    .leftJoin('profiles as profile', 'users.id', 'profile.user_id')
+    .where('users.id', id)
+    .select(
+      'profile.name as profileName',
+      'profile.id as profileId',
+      'users.id ',
+      'users.email'
+    )
+}

--- a/core/src/plugins/routes.ts
+++ b/core/src/plugins/routes.ts
@@ -1,0 +1,17 @@
+import fp from 'fastify-plugin'
+
+export default fp(
+  function (fastify, options, done) {
+    fastify.after(() => {
+      fastify.get('/api/me', (req, res) => {
+        //TODO: add authentication check
+        const currentUserId = 1
+        return fastify.domain.user.fetchUserById(currentUserId)
+      })
+    })
+    done()
+  },
+  {
+    name: 'routes',
+  }
+)

--- a/core/src/server.ts
+++ b/core/src/server.ts
@@ -1,0 +1,14 @@
+import { createServer } from './app'
+
+function main() {
+  const app = createServer()
+  app.listen({ port: app.config.port }, err => {
+    if (err) {
+      app.log.error(err.message)
+      process.exit(1)
+    }
+    app.log.info('http://127.0.0.1:8000/foo')
+  })
+}
+
+main()

--- a/core/src/types.d.ts
+++ b/core/src/types.d.ts
@@ -1,0 +1,12 @@
+import { auth } from 'firebase-admin'
+import { Config } from './config'
+import { Knex } from 'knex'
+import { Domain } from './plugins/domain/domain'
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    config: Config
+    knex: Knex
+    domain: Domain
+  }
+}

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "ES2020",
+    "target": "ES2020",
+    "outDir": "dist",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "types": ["./src/types.d.ts"]
+  }
+}

--- a/core/vite.config.ts
+++ b/core/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite'
+import fastify from 'vite-plugin-fastify'
+import { resolve } from 'path'
+
+export default defineConfig({
+  server: {
+    host: '127.0.0.1',
+    port: 3000,
+  },
+  plugins: [
+    fastify({
+      appPath: './src/app.ts',
+      serverPath: './src/server.ts',
+    }),
+  ],
+  resolve: {
+    alias: {
+      '~': resolve(__dirname, 'src'),
+    },
+  },
+})


### PR DESCRIPTION
The repository requires a lot of cleanup, this is an attempt to move it to a more manageable state. 

Primarily, the aim to make it easier to use something like vite to bundle instead of tying the whole thing to something like Next.js 

Rules for this refactor, nothing should be re-implemented but instead should be just moved into using the backend from the `core` package. 

The existing next.js app should be left as is and just change the API requests to be sent to the now newly written fastify based server. 

The next.js app once decoupled from the server code can be moved to another vite react app later 

